### PR TITLE
MetaceloPackageSpec workingCopyNameFor call name which could lead to …

### DIFF
--- a/repository/Metacello-MC.package/MetacelloPackageSpec.class/instance/workingCopyNameFor..st
+++ b/repository/Metacello-MC.package/MetacelloPackageSpec.class/instance/workingCopyNameFor..st
@@ -3,4 +3,4 @@ workingCopyNameFor: anMCLoader
 
 	| vi |
 	(vi := anMCLoader currentVersionInfoFor: self) == nil ifTrue: [ ^nil ].
-	^vi name
+	^vi isArray ifTrue: [ vi printString ] ifFalse: [ vi name ]

--- a/repository/Metacello-MC.package/MetacelloPackageSpec.class/methodProperties.json
+++ b/repository/Metacello-MC.package/MetacelloPackageSpec.class/methodProperties.json
@@ -82,4 +82,4 @@
 		"visitingWithPackages:" : "dkh 6/8/2012 14:04:22",
 		"workingCopy" : "dkh 6/8/2012 14:04:22",
 		"workingCopyName" : "dkh 6/8/2012 14:04:22",
-		"workingCopyNameFor:" : "dkh 6/8/2012 14:04:22" } }
+		"workingCopyNameFor:" : "CyrilFerlicot 8/21/2017 18:05:22" } }


### PR DESCRIPTION
…deprecation warning when current version is array in Pharo

Related issue: https://github.com/dalehenrich/metacello-work/issues/446