### PR TITLE
Correct problem with file deletion on windows

### DIFF
--- a/repository/Metacello-GitBasedRepository.package/MCGitBasedNetworkRepository.class/class/projectDirectoryFrom.version..st
+++ b/repository/Metacello-GitBasedRepository.package/MCGitBasedNetworkRepository.class/class/projectDirectoryFrom.version..st
@@ -22,21 +22,22 @@ projectDirectoryFrom: projectPath version: versionString
 			url := self
 				projectZipUrlFor: projectPath
 				versionString: versionString.
-			pid := MetacelloPlatform current processPID.
-			zipFileName := MetacelloPlatform current
+			pid := mcPlatform processPID.
+			zipFileName := mcPlatform
 				tempFileFor:
 					self basicDescription , '-' , pid , '-'
 						, (downloadCacheKey select: [ :c | c isAlphaNumeric ])
 				suffix: '.zip'.
-			archive := MetacelloPlatform current
+			archive := mcPlatform
 				downloadZipArchive: url
 				to: zipFileName.
 			directory := mcPlatform
 				directoryFromPath: (cachePath := archive members first fileName)
 				relativeTo: theCacheDirectory.
+			archive close.
 			directory exists
-				ifTrue: [ MetacelloPlatform current deleteFileNamed: zipFileName ]
-				ifFalse: [ MetacelloPlatform current
+				ifTrue: [ mcPlatform deleteFileNamed: zipFileName ]
+				ifFalse: [ mcPlatform
 						extractRepositoryFrom: zipFileName
 						to: theCacheDirectory fullName ].
 			self downloadCache at: downloadCacheKey put: cachePath.


### PR DESCRIPTION
Close the archive before deleting it in MCGitBasedNetworkRepository class>>projectDirectoryFrom:version:

Also, there is a small cleaning of the code.

Fixes https://github.com/Metacello/metacello/issues/484