### PR TITLE
Metacello test  patches - reduce random test failures (api rate limits)

### DIFF
--- a/repository/Metacello-TestsMCA.package/MetacelloGithubIssue277TestCase.class/instance/testBitbucketRepositoryPatternMatchingA.st
+++ b/repository/Metacello-TestsMCA.package/MetacelloGithubIssue277TestCase.class/instance/testBitbucketRepositoryPatternMatchingA.st
@@ -1,5 +1,12 @@
 tests
 testBitbucketRepositoryPatternMatchingA
+  "
+UserDefinedError: Error accessing tags for bitbucket project: 'dalehenrich/external' -> 'Resource removed' :: 'This API is no longer supported.
+For information about its removal, please refer to the deprecation notice at: https://developer.atlassian.com/cloud/bitbucket/deprecation-notice-v1-apis/'
+"
+
+  true
+    ifTrue: [ ^ self ].
   [ 
   | repo x |
   repo := MCBitbucketRepository
@@ -11,9 +18,7 @@ testBitbucketRepositoryPatternMatchingA
       Transcript
         cr;
         show:
-            'expected testBitbucketRepositoryPatternMatchingA failure: ' , ex description;
-        cr;
-        show: (GsProcess stackReportToLevel: 100).
+            'expected testBitbucketRepositoryPatternMatchingA failure: ' , ex description.
       false
         ifTrue: [ 
           "don't fail test ... see https://github.com/dalehenrich/metacello-work/issues/359"

--- a/repository/Metacello-TestsPlatform.gemstone.package/MetacelloRepositoryGemStoneTestCase.class/instance/testIssue332DownloadTags.st
+++ b/repository/Metacello-TestsPlatform.gemstone.package/MetacelloRepositoryGemStoneTestCase.class/instance/testIssue332DownloadTags.st
@@ -2,6 +2,13 @@ tests
 testIssue332DownloadTags
   "https://github.com/dalehenrich/metacello-work/issues/332"
 
+  "Expecting that the rate limit remaining NOT change while running a test
+		is not realistic, since other processes running on the same machine 
+		MAY be counting against the rate limit --- record rate limits in log, 
+		but don't assert that the limit hasn't changed"
+
+  "https://github.com/Metacello/metacello/issues/510"
+
   [ 
   | repo tags cache expectedTags rateLimitRemaining x |
   cache := MCGitHubRepository eTagsCache.
@@ -11,13 +18,17 @@ testIssue332DownloadTags
   tags := repo downloadJSONTags.	"prime the value of X-RateLimit-Remaining"
   rateLimitRemaining := (cache at: 'dalehenrich/external')
     at: 'X-RateLimit-Remaining'.
+  Transcript
+    cr;
+    show:
+        'testIssue332DownloadTags initial rate limit ' , rateLimitRemaining asString.
   tags := repo downloadJSONTags.
   expectedTags := #('1.0-beta.32Tests' 'v1.1.1-gs' 'v1.1.2-gs' 'v1.2.0-gs' 'v1.2.0.1-gs' 'v1.2.0.2-gs' 'v1.3.0-gs' 'v2.1.0-gs' 'v2.2.0-gs' 'v3.0.0-gs').
   expectedTags do: [ :tag | tags at: tag ifAbsent: [ self assert: false ] ].
-  self
-    assert:
-      rateLimitRemaining
-        = (x := (cache at: 'dalehenrich/external') at: 'X-RateLimit-Remaining') ]
+  x := (cache at: 'dalehenrich/external') at: 'X-RateLimit-Remaining'.
+  Transcript
+    cr;
+    show: 'testIssue332DownloadTags final rate limit: ' , x asString ]
     on: Error
     do: [ :ex | 
       "keep an eye out for rate limiting errors from github for anonymous api usage"


### PR DESCRIPTION
Bitbucket no longer supports tag API used by Metacello; unreasonable for a test to assume that rate limit will not change on shared machine ... attempt to reduce random test failures for Issue #510 and Issue #332.